### PR TITLE
fix (site links): fixes  wrong github website link  & blog post links to

### DIFF
--- a/base.html
+++ b/base.html
@@ -67,7 +67,7 @@
     Data &copy; V. Krishna <span class="slash">•</span>
     <a href="https://github.com/knadh/dictmaker">built with dictmaker</a> <span class="slash">•</span>
     supported by
-    <a href="https://zerodha.tech/alar-open-source-kannada-english-dictionary" class="credit"><img src="https://zerodha.com/static/images/logo.svg"
+    <a href="https://zerodha.tech/blog/alar-the-making-of-an-open-source-dictionary/" class="credit"><img src="https://zerodha.com/static/images/logo.svg"
         alt="Zerodha" /></a>
   </footer>
   <script src="/static/autocomplete.js"></script>

--- a/pages/about.html
+++ b/pages/about.html
@@ -48,7 +48,7 @@
         This website is published using <a href="https://github.com/knadh/dictmaker">dictmaker</a>,
         and uses <a href="https://github.com/knadh/knphone">knphone</a>, a Kannada phonetic
         indexing algorithm, for search. Search suggestions and transliterations are powered by <a href="https://github.com/varnamproject">Varnam</a>.      
-        The website's source is <a href="https://github.com/alar-dict/website">available here</a>.
+        The website's source is <a href="https://github.com/alar-dict/alar.ink">available here</a>.
     </p>
     <p>
         Technical feedback can be sent to <a href="mailto:kailash&#064;nadh.in">kailash&#064;nadh.in</a>.


### PR DESCRIPTION
Links to blog post published for alar intro & the website repo link which was pointing wrong urls are fixed,