### PR TITLE
Modify glossary hyperlink label with appropriate kannada word

### DIFF
--- a/base.html
+++ b/base.html
@@ -59,7 +59,7 @@
 {{ define "footer" }}
     <div id="fakelog"></div>
     <nav class="nav">
-      <a href="/glossary/kannada/english/ಅ">ಪದಗಳ ಗ್ಲಾಸರಿ (Glossary)</a>
+      <a href="/glossary/kannada/english/ಅ">ಶಬ್ದಸಂಗ್ರಹ (Glossary)</a>
       <a href="/pages/about">ಬಗ್ಗೆ (About)</a>
     </nav>
   </div>


### PR DESCRIPTION
Found the word and definition [here](https://www.multibhashi.com/glossary-meaning-in-kannada/).
The definition for `ಶಬ್ದಸಂಗ್ರಹ` was more apt to be used in place of `ಪದಗಳ ಗ್ಲಾಸರಿ` for glossary.