### PR TITLE
fix hyperlink formation of Kannada words

### DIFF
--- a/static/global.js
+++ b/static/global.js
@@ -92,7 +92,6 @@ function hasKannadaChar(str) {
 
 
 (function() {
-    const reMatchKannadaWord = new RegExp(/[\u0C80-\u0CFF]+/g);
     const reMatchNonKannadaBlobs = new RegExp(/[^\u0C80-\u0CFF]+/g);
   // In the results (definitions), if there are Kannada words, hyperlink
   // them to search.
@@ -120,14 +119,18 @@ function hasKannadaChar(str) {
         // Non-ASCII word. Turn into a link.
         const a = document.createElement("a");
 
-        // Some Kannada words have numbers or "." at the end of them
-        // They need to be cleaned, else they'll be part of the query, and fudge results
+        // Some Kannada words have non-Kannada characters around them,
+        // the hyperlink should be formed only for Kannada words, while retaining all the characters order
         const kannadaWord = v.replace(reMatchNonKannadaBlobs, "");
-        const nonKannadaTrailingSymbol = v.replace(reMatchKannadaWord,"");
+        const nonKannadaWords = v.split(kannadaWord);
+
+        nonKannadaWords[0] && s.appendChild(document.createTextNode(nonKannadaWords[0]));
+
         a.setAttribute("href", kannadaWord);
         a.appendChild(document.createTextNode(kannadaWord));
         s.appendChild(a);
-        s.appendChild(document.createTextNode(nonKannadaTrailingSymbol));
+
+        nonKannadaWords[1] && s.appendChild(document.createTextNode(nonKannadaWords[1]));
       }
 
       // Append a space.


### PR DESCRIPTION
## Issue
The current logic (from the commit #5) misplaced the leading non-Kannada characters when forming the hyperlink for Kannada words.
### Example
When there are leading non-Kannada characters in a Kannada word in the meaning definitions, the leading characters goes after the Kannada word when the hyperlink is formed. Below are some scenarios:
- If the original sentence is `pronounced with the vowel 'ಅ'`, this sentence after forming hyperlink becomes `pronounced with the vowel ಅ''` (Reference: [ಕ](https://alar.ink/dictionary/kannada/english/%E0%B2%95))
- If the original sentence is `articulated with one or two lips (ಪ, ಫ, ಬ, ಭ);`, this sentence after forming hyperlink becomes `articulated with one or two lips ಪ(, ಫ, ಬ, ಭ);` (Reference: [ಔಷ್ಠ್ಯವರ್ಣ](https://alar.ink/dictionary/kannada/english/%E0%B2%94%E0%B2%B7%E0%B3%8D%E0%B2%A0%E0%B3%8D%E0%B2%AF%E0%B2%B5%E0%B2%B0%E0%B3%8D%E0%B2%A3))
### Screenshots
![image](https://github.com/alar-dict/alar.ink/assets/41661218/7a896b75-4ab7-4962-9387-783d1b7fbb27)
![image](https://github.com/alar-dict/alar.ink/assets/41661218/e35b9d1b-3139-4049-b251-993a3a6d092f)
## Fix
From the non-ASCII word, the Kannada word is extracted from the existing regex. This Kannada word is used to split the whole word, which will always return an array of 2 elements. This array contains the elements of non-Kannada words. The 0th index value (if non empty string) is appended first to the `span` element, then the hyperlink element is appended and finally the 1st index value (if non empty string) is appended.
### Screenshots
![image](https://github.com/alar-dict/alar.ink/assets/41661218/bfd0bb4e-0aeb-42e9-87e5-ead8993025cf)
![image](https://github.com/alar-dict/alar.ink/assets/41661218/5fa2782d-a88f-4756-8155-6253991d55ab)
